### PR TITLE
never send rnr flag as true to conversation

### DIFF
--- a/src/main/java/com/ibm/watson/apis/conversation_enhanced/rest/ProxyResource.java
+++ b/src/main/java/com/ibm/watson/apis/conversation_enhanced/rest/ProxyResource.java
@@ -122,7 +122,8 @@ public class ProxyResource {
 
     // Determine if conversation's response is sufficient to answer the user's question or if we
     // should call the retrieve and rank service to obtain better answers
-    if (response.getContext().containsKey("call_retrieve_and_rank")) {
+    if (response.getContext().containsKey("call_retrieve_and_rank") &&
+    		(boolean)(response.getContext().get("call_retrieve_and_rank")) == true) {
       String query = response.getInputText();
 
       // Extract the user's original query from the conversational response

--- a/src/main/webapp/ts/app.component.ts
+++ b/src/main/webapp/ts/app.component.ts
@@ -321,7 +321,7 @@ export class AppComponent {
     let ce : any = null;
     // Before calling conversation, set the call_retrieve_and_rank flag to false
     // conversation and not the app should control when retrieve and rank is called
-    if (typeof payload.context !== 'undefined') {
+    if (payload.context) {
        payload.context.call_retrieve_and_rank = false;
     }
     // Send the user utterance to dialog, also send previous context

--- a/src/main/webapp/ts/app.component.ts
+++ b/src/main/webapp/ts/app.component.ts
@@ -319,6 +319,11 @@ export class AppComponent {
   private callConversationService (chatColumn, payload) {
     let responseText = '';
     let ce : any = null;
+    // Before calling conversation, set the call_retrieve_and_rank flag to false
+    // conversation and not the app should control when retrieve and rank is called
+    if (typeof payload.context !== 'undefined') {
+       payload.context.call_retrieve_and_rank = false;
+    }
     // Send the user utterance to dialog, also send previous context
     this._dialogService.message (this.workspace_id, payload).subscribe (
       data1 => {


### PR DESCRIPTION
Only Conversation should set the call_retrieve_and_rank to true. The app should reset it during each call so it can tell if Conversation set it recently
