### PR TITLE
Fixed bug with error message getting a null pointer on e.getMessage()

### DIFF
--- a/src/main/java/com/ibm/watson/apis/conversation_with_discovery/rest/ProxyResource.java
+++ b/src/main/java/com/ibm/watson/apis/conversation_with_discovery/rest/ProxyResource.java
@@ -189,7 +189,7 @@ public class ProxyResource {
         errorsOutput.put(ERROR, e.getMessage());
       } else if (e instanceof MalformedURLException) {
         errorsOutput.put(ERROR, Messages.getString("ProxyResource.MALFORMED_URL"));
-      } else if (e.getMessage().contains("URL workspaceid parameter is not a valid GUID.")) {
+      } else if (e.getMessage() != null && e.getMessage().contains("URL workspaceid parameter is not a valid GUID.")) {
         errorsOutput.put(ERROR, Messages.getString("ProxyResource.INVALID_WORKSPACEID"));
       } else {
         errorsOutput.put(ERROR, Messages.getString("ProxyResource.GENERIC_ERROR"));


### PR DESCRIPTION
https://developer.ibm.com/answers/questions/388685/connecting-own-discovery-collection-to-conversatio/

Not sure whats wrong with this user account, but the null pointer is due to the exception having a null message